### PR TITLE
Add copy() function to the DataFrame class as discussed in issue #11.

### DIFF
--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
@@ -827,13 +827,14 @@ public class DataFrame
 
         if (selectedColumnNamesToCopy == null)
         {
-            this.columns.forEach(col -> col.mergeWithInto(col, copied));
+            this.columns.forEach(col -> col.copyTo(copied));
+            copied.seal();
             return copied;
         }
 
         ListIterable<DfColumn> columnsToCopy = selectedColumnNamesToCopy.collect(this::getColumnNamed);
-        columnsToCopy.forEach(col -> col.mergeWithInto(col, copied));
-
+        columnsToCopy.forEach(col -> col.copyTo(copied));
+        copied.seal();
         return copied;
     }
 

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
@@ -818,22 +818,17 @@ public class DataFrame
      * If the list is set to null, all columns are copied (behaving in the same way as copy(String newName)).
      *
      * @param newName the name for the new data frame
-     * @param selectedColumnNamesToCopy the names of the columns to be copied
+     * @param columnNamesToCopy the names of the columns to be copied
      * @return a copy of the original data frame with the provided name and new schema
      */
-    public DataFrame copy(String newName, ListIterable<String> selectedColumnNamesToCopy)
+    public DataFrame copy(String newName, ListIterable<String> columnNamesToCopy)
     {
         DataFrame copied =  new DataFrame(newName);
 
-        if (selectedColumnNamesToCopy == null)
-        {
-            this.columns.forEach(col -> col.copyTo(copied));
-        }
-        else
-        {
-            ListIterable<DfColumn> columnsToCopy = selectedColumnNamesToCopy.collect(this::getColumnNamed);
-            columnsToCopy.forEach(col -> col.copyTo(copied));
-        }
+        ((columnNamesToCopy == null)
+                ? this.columns
+                : columnNamesToCopy.collect(this::getColumnNamed)
+        ).forEach(col -> col.copyTo(copied));
 
         copied.seal();
         return copied;

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
@@ -800,6 +800,43 @@ public class DataFrame
         return cloned;
     }
 
+    /**
+     * creates a copy of the whole data frame with the same schema as the original, including computed columns that
+     * are converted to stored columns of the same type
+     *
+     * @param newName the name for the new data frame
+     * @return a copy of the original data frame with the provided name and new schema
+     */
+    public DataFrame copy(String newName)
+    {
+        return this.copy(newName, null);
+    }
+
+    /**
+     * creates a copy of the parts of data frame with the same schema as the original, including computed columns that
+     * are converted to stored columns of the same type. Only the provided columns are copied to the new data frame.
+     * If the list is set to null, all columns are copied (behaving in the same way as copy(String newName)).
+     *
+     * @param newName the name for the new data frame
+     * @param selectedColumnNamesToCopy the names of the columns to be copied
+     * @return a copy of the original data frame with the provided name and new schema
+     */
+    public DataFrame copy(String newName, ListIterable<String> selectedColumnNamesToCopy)
+    {
+        DataFrame copied =  new DataFrame(newName);
+
+        if (selectedColumnNamesToCopy == null)
+        {
+            this.columns.forEach(col -> col.mergeWithInto(col, copied));
+            return copied;
+        }
+
+        ListIterable<DfColumn> columnsToCopy = selectedColumnNamesToCopy.collect(this::getColumnNamed);
+        columnsToCopy.forEach(col -> col.mergeWithInto(col, copied));
+
+        return copied;
+    }
+
     public DataFrame sortBy(ListIterable<String> columnsToSortByNames)
     {
         return this.sortBy(columnsToSortByNames, null);

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
@@ -828,12 +828,13 @@ public class DataFrame
         if (selectedColumnNamesToCopy == null)
         {
             this.columns.forEach(col -> col.copyTo(copied));
-            copied.seal();
-            return copied;
+        }
+        else
+        {
+            ListIterable<DfColumn> columnsToCopy = selectedColumnNamesToCopy.collect(this::getColumnNamed);
+            columnsToCopy.forEach(col -> col.copyTo(copied));
         }
 
-        ListIterable<DfColumn> columnsToCopy = selectedColumnNamesToCopy.collect(this::getColumnNamed);
-        columnsToCopy.forEach(col -> col.copyTo(copied));
         copied.seal();
         return copied;
     }

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumn.java
@@ -68,6 +68,8 @@ public interface DfColumn
 
     DfColumn mergeWithInto(DfColumn other, DataFrame target);
 
+    DfColumn copyTo(DataFrame target);
+
     default DfCellComparator columnComparator(DfColumn otherColumn)
     {
         throw ErrorReporter.unsupported("Column comparator is not implemented for column "

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumnAbstract.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumnAbstract.java
@@ -89,7 +89,7 @@ implements DfColumn
         return newColumn;
     }
 
-    protected DfColumn copyColumn(DataFrame target)
+    protected DfColumn copyColumnSchema(DataFrame target)
     {
         target.addColumn(this.getName(), this.getType());
 

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumnAbstract.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumnAbstract.java
@@ -99,8 +99,7 @@ implements DfColumn
         return newColumn;
     }
 
-    protected DfColumn copyColumnSchema(DataFrame target)
-    {
+    protected DfColumn copyColumnSchema(DataFrame target) {
         target.addColumn(this.getName(), this.getType());
 
         DfColumnStored newColumn = (DfColumnStored) target.getColumnAt(target.columnCount() - 1);
@@ -108,6 +107,7 @@ implements DfColumn
         newColumn.ensureInitialCapacity(this.getSize());
 
         return newColumn;
+    }
 
     protected void throwAddingIncompatibleValueException(Value value)
     {

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumnAbstract.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumnAbstract.java
@@ -88,4 +88,15 @@ implements DfColumn
 
         return newColumn;
     }
+
+    protected DfColumn copyColumn(DataFrame target)
+    {
+        target.addColumn(this.getName(), this.getType());
+
+        DfColumnStored newColumn = (DfColumnStored) target.getColumnAt(target.columnCount() - 1);
+
+        newColumn.ensureInitialCapacity(this.getSize());
+
+        return newColumn;
+    }
 }

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfDoubleColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfDoubleColumn.java
@@ -65,6 +65,14 @@ extends DfColumnAbstract
         return mergedCol;
     }
 
+    public DfColumn copyTo(DataFrame target)
+    {
+        DfDoubleColumn mergedCol = (DfDoubleColumn) this.copyColumn(target);
+
+        mergedCol.addAllItemsFrom(this);
+        return mergedCol;
+    }
+
     protected abstract void addAllItemsFrom(DfDoubleColumn doubleColumn);
 
     @Override

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfDoubleColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfDoubleColumn.java
@@ -67,10 +67,10 @@ extends DfColumnAbstract
 
     public DfColumn copyTo(DataFrame target)
     {
-        DfDoubleColumn mergedCol = (DfDoubleColumn) this.copyColumnSchema(target);
+        DfDoubleColumn tagetCol = (DfDoubleColumn) this.copyColumnSchema(target);
 
-        mergedCol.addAllItemsFrom(this);
-        return mergedCol;
+        tagetCol.addAllItemsFrom(this);
+        return tagetCol;
     }
 
     protected abstract void addAllItemsFrom(DfDoubleColumn doubleColumn);

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfDoubleColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfDoubleColumn.java
@@ -67,7 +67,7 @@ extends DfColumnAbstract
 
     public DfColumn copyTo(DataFrame target)
     {
-        DfDoubleColumn mergedCol = (DfDoubleColumn) this.copyColumn(target);
+        DfDoubleColumn mergedCol = (DfDoubleColumn) this.copyColumnSchema(target);
 
         mergedCol.addAllItemsFrom(this);
         return mergedCol;

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfLongColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfLongColumn.java
@@ -67,10 +67,10 @@ extends DfColumnAbstract
 
     public DfColumn copyTo(DataFrame target)
     {
-        DfLongColumn mergedCol = (DfLongColumn)  this.copyColumnSchema(target);
+        DfLongColumn tagetCol = (DfLongColumn)  this.copyColumnSchema(target);
 
-        mergedCol.addAllItemsFrom(this);
-        return mergedCol;
+        tagetCol.addAllItemsFrom(this);
+        return tagetCol;
     }
 
     protected abstract void addAllItemsFrom(DfLongColumn items);

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfLongColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfLongColumn.java
@@ -65,6 +65,14 @@ extends DfColumnAbstract
         return mergedCol;
     }
 
+    public DfColumn copyTo(DataFrame target)
+    {
+        DfLongColumn mergedCol = (DfLongColumn)  this.copyColumn(target);
+
+        mergedCol.addAllItemsFrom(this);
+        return mergedCol;
+    }
+
     protected abstract void addAllItemsFrom(DfLongColumn items);
 
     @Override

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfLongColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfLongColumn.java
@@ -67,7 +67,7 @@ extends DfColumnAbstract
 
     public DfColumn copyTo(DataFrame target)
     {
-        DfLongColumn mergedCol = (DfLongColumn)  this.copyColumn(target);
+        DfLongColumn mergedCol = (DfLongColumn)  this.copyColumnSchema(target);
 
         mergedCol.addAllItemsFrom(this);
         return mergedCol;

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfObjectColumnAbstract.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfObjectColumnAbstract.java
@@ -31,7 +31,7 @@ implements DfObjectColumn<T>
 
     public DfColumn copyTo(DataFrame target)
     {
-        DfObjectColumnAbstract<T> mergedCol = (DfObjectColumnAbstract<T>) this.copyColumn(target);
+        DfObjectColumnAbstract<T> mergedCol = (DfObjectColumnAbstract<T>) this.copyColumnSchema(target);
 
         mergedCol.addAllItems(this.toList());
         return mergedCol;

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfObjectColumnAbstract.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfObjectColumnAbstract.java
@@ -31,9 +31,9 @@ implements DfObjectColumn<T>
 
     public DfColumn copyTo(DataFrame target)
     {
-        DfObjectColumnAbstract<T> mergedCol = (DfObjectColumnAbstract<T>) this.copyColumnSchema(target);
+        DfObjectColumnAbstract<T> tagetCol = (DfObjectColumnAbstract<T>) this.copyColumnSchema(target);
 
-        mergedCol.addAllItems(this.toList());
-        return mergedCol;
+        tagetCol.addAllItems(this.toList());
+        return tagetCol;
     }
 }

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfObjectColumnAbstract.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfObjectColumnAbstract.java
@@ -28,4 +28,12 @@ implements DfObjectColumn<T>
         mergedCol.addAllItems(((DfObjectColumnAbstract<T>) other).toList());
         return mergedCol;
     }
+
+    public DfColumn copyTo(DataFrame target)
+    {
+        DfObjectColumnAbstract<T> mergedCol = (DfObjectColumnAbstract<T>) this.copyColumn(target);
+
+        mergedCol.addAllItems(this.toList());
+        return mergedCol;
+    }
 }

--- a/src/test/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrameCopyTest.java
+++ b/src/test/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrameCopyTest.java
@@ -1,5 +1,8 @@
 package io.github.vmzakharov.ecdataframe.dataframe;
 
+import io.github.vmzakharov.ecdataframe.dsl.value.Value;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -65,6 +68,80 @@ public class DataFrameCopyTest
             Assert.assertEquals(sourceColumn.getType(), copyColumn.getType());
             Assert.assertTrue(copyColumn.isStored());
             Assert.assertSame(clonedSchema, copyColumn.getDataFrame());
+        }
+    }
+
+    @Test
+    public void copyWholeDataFrame()
+    {
+        DataFrame df = new DataFrame("df1");
+        df.addStringColumn("Name").addLongColumn("Count").addDoubleColumn("Value");
+        df
+                .addRow("Alice", 5, 23.45)
+                .addRow("Bob",  10, 12.34)
+                .addRow("Carl", 11, 56.78)
+                .addRow("Deb",   0,  7.89);
+
+        df.addDoubleColumn("Twice", "Value * 2");
+
+        DataFrame copiedSchema = df.copy("MyNewCopy");
+
+        Assert.assertEquals(0, copiedSchema.rowCount());
+        Assert.assertEquals(df.columnCount(), copiedSchema.columnCount());
+        for (int i = 0; i < df.columnCount(); i++)
+        {
+            DfColumn sourceColumn = df.getColumnAt(i);
+            DfColumn copyColumn = copiedSchema.getColumnAt(i);
+
+            Assert.assertEquals(sourceColumn.getName(), copyColumn.getName());
+            Assert.assertEquals(sourceColumn.getType(), copyColumn.getType());
+            Assert.assertTrue(copyColumn.isStored());
+            Assert.assertSame(copiedSchema, copyColumn.getDataFrame());
+
+            for (int j = 0; j < df.rowCount(); j++)
+            {
+                Value cellValue = df.getColumnAt(i).getValue(j);
+                Value copiedCellValue = copiedSchema.getColumnAt(i).getValue(j);
+
+                Assert.assertEquals(0, cellValue.compareTo(copiedCellValue));
+            }
+        }
+    }
+
+    @Test
+    public void copySomeColumnsToANewDataFrame()
+    {
+        DataFrame df = new DataFrame("df1");
+        df.addStringColumn("Name").addLongColumn("Count").addDoubleColumn("Value");
+        df
+                .addRow("Alice", 5, 23.45)
+                .addRow("Bob",  10, 12.34)
+                .addRow("Carl", 11, 56.78)
+                .addRow("Deb",   0,  7.89);
+
+        df.addDoubleColumn("Twice", "Value * 2");
+
+        ImmutableList<String> columnNamesToCopy = Lists.immutable.of("Name", "Twice");
+        DataFrame copiedSchema = df.copy("MyNewCopy", columnNamesToCopy);
+
+        Assert.assertEquals(0, copiedSchema.rowCount());
+        Assert.assertEquals(columnNamesToCopy.size(), copiedSchema.columnCount());
+        for (int i = 0; i < columnNamesToCopy.size(); i++)
+        {
+            DfColumn copyColumn = copiedSchema.getColumnAt(i);
+            DfColumn sourceColumn = df.getColumnNamed(copyColumn.getName());
+
+            Assert.assertEquals(sourceColumn.getName(), copyColumn.getName());
+            Assert.assertEquals(sourceColumn.getType(), copyColumn.getType());
+            Assert.assertTrue(copyColumn.isStored());
+
+            for (int j = 0; j < df.rowCount(); j++)
+            {
+                Value cellValue = df.getColumnNamed(copyColumn.getName()).getValue(j);
+                Value copiedCellValue = copiedSchema.getColumnAt(i).getValue(j);
+
+                Assert.assertEquals(0, cellValue.compareTo(copiedCellValue));
+            }
         }
     }
 }

--- a/src/test/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrameCopyTest.java
+++ b/src/test/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrameCopyTest.java
@@ -1,6 +1,5 @@
 package io.github.vmzakharov.ecdataframe.dataframe;
 
-import io.github.vmzakharov.ecdataframe.dsl.value.Value;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.junit.Assert;
@@ -12,7 +11,10 @@ public class DataFrameCopyTest
     public void copySchema()
     {
         DataFrame df = new DataFrame("df1");
-        df.addStringColumn("Name").addLongColumn("Count").addDoubleColumn("Value");
+        df
+                .addStringColumn("Name")
+                .addLongColumn("Count")
+                .addDoubleColumn("Value");
         df
                 .addRow("Alice", 5, 23.45)
                 .addRow("Bob",  10, 12.34)
@@ -46,7 +48,10 @@ public class DataFrameCopyTest
     public void copySchemaConvertComputedToStored()
     {
         DataFrame df = new DataFrame("df1");
-        df.addStringColumn("Name").addLongColumn("Count").addDoubleColumn("Value");
+        df
+                .addStringColumn("Name")
+                .addLongColumn("Count")
+                .addDoubleColumn("Value");
         df
                 .addRow("Alice", 5, 23.45)
                 .addRow("Bob",  10, 12.34)
@@ -75,7 +80,10 @@ public class DataFrameCopyTest
     public void copyWholeDataFrame()
     {
         DataFrame df = new DataFrame("df1");
-        df.addStringColumn("Name").addLongColumn("Count").addDoubleColumn("Value");
+        df
+                .addStringColumn("Name")
+                .addLongColumn("Count")
+                .addDoubleColumn("Value");
         df
                 .addRow("Alice", 5, 23.45)
                 .addRow("Bob",  10, 12.34)
@@ -93,37 +101,34 @@ public class DataFrameCopyTest
     @Test
     public void copySomeColumnsToANewDataFrame()
     {
-        DataFrame df = new DataFrame("df1");
-        df.addStringColumn("Name").addLongColumn("Count").addDoubleColumn("Value");
-        df
+        DataFrame originalDataFrame = new DataFrame("df1");
+        originalDataFrame
+                .addStringColumn("Name")
+                .addLongColumn("Count")
+                .addDoubleColumn("Value");
+
+        originalDataFrame
                 .addRow("Alice", 5, 23.45)
                 .addRow("Bob",  10, 12.34)
                 .addRow("Carl", 11, 56.78)
                 .addRow("Deb",   0,  7.89);
 
-        df.addDoubleColumn("Twice", "Value * 2");
+        originalDataFrame.addDoubleColumn("Twice", "Value * 2");
+
+        DataFrame expectedDataFrame = new DataFrame("df2");
+        expectedDataFrame
+                .addStringColumn("Name")
+                .addDoubleColumn("Twice");
+
+        expectedDataFrame
+                .addRow("Alice",  46.9)
+                .addRow("Bob",    24.68)
+                .addRow("Carl",  113.56)
+                .addRow("Deb",    15.78);
 
         ImmutableList<String> columnNamesToCopy = Lists.immutable.of("Name", "Twice");
-        DataFrame copiedDataFrame = df.copy("MyNewCopy", columnNamesToCopy);
+        DataFrame copiedDataFrame = originalDataFrame.copy("MyNewCopy", columnNamesToCopy);
 
-        Assert.assertEquals(df.rowCount(), copiedDataFrame.rowCount());
-        Assert.assertEquals(columnNamesToCopy.size(), copiedDataFrame.columnCount());
-        for (int i = 0; i < columnNamesToCopy.size(); i++)
-        {
-            DfColumn copyColumn = copiedDataFrame.getColumnAt(i);
-            DfColumn sourceColumn = df.getColumnNamed(copyColumn.getName());
-
-            Assert.assertEquals(sourceColumn.getName(), copyColumn.getName());
-            Assert.assertEquals(sourceColumn.getType(), copyColumn.getType());
-            Assert.assertTrue(copyColumn.isStored());
-
-            for (int j = 0; j < df.rowCount(); j++)
-            {
-                Value cellValue = df.getColumnNamed(copyColumn.getName()).getValue(j);
-                Value copiedCellValue = copiedDataFrame.getColumnAt(i).getValue(j);
-
-                Assert.assertEquals(0, cellValue.compareTo(copiedCellValue));
-            }
-        }
+        DataFrameUtil.assertEquals(expectedDataFrame, copiedDataFrame);
     }
 }

--- a/src/test/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrameCopyTest.java
+++ b/src/test/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrameCopyTest.java
@@ -84,28 +84,10 @@ public class DataFrameCopyTest
 
         df.addDoubleColumn("Twice", "Value * 2");
 
-        DataFrame copiedSchema = df.copy("MyNewCopy");
+        DataFrame copiedDataFrame = df.copy("MyNewCopy");
 
-        Assert.assertEquals(0, copiedSchema.rowCount());
-        Assert.assertEquals(df.columnCount(), copiedSchema.columnCount());
-        for (int i = 0; i < df.columnCount(); i++)
-        {
-            DfColumn sourceColumn = df.getColumnAt(i);
-            DfColumn copyColumn = copiedSchema.getColumnAt(i);
+        DataFrameUtil.assertEquals(df, copiedDataFrame);
 
-            Assert.assertEquals(sourceColumn.getName(), copyColumn.getName());
-            Assert.assertEquals(sourceColumn.getType(), copyColumn.getType());
-            Assert.assertTrue(copyColumn.isStored());
-            Assert.assertSame(copiedSchema, copyColumn.getDataFrame());
-
-            for (int j = 0; j < df.rowCount(); j++)
-            {
-                Value cellValue = df.getColumnAt(i).getValue(j);
-                Value copiedCellValue = copiedSchema.getColumnAt(i).getValue(j);
-
-                Assert.assertEquals(0, cellValue.compareTo(copiedCellValue));
-            }
-        }
     }
 
     @Test
@@ -122,13 +104,13 @@ public class DataFrameCopyTest
         df.addDoubleColumn("Twice", "Value * 2");
 
         ImmutableList<String> columnNamesToCopy = Lists.immutable.of("Name", "Twice");
-        DataFrame copiedSchema = df.copy("MyNewCopy", columnNamesToCopy);
+        DataFrame copiedDataFrame = df.copy("MyNewCopy", columnNamesToCopy);
 
-        Assert.assertEquals(0, copiedSchema.rowCount());
-        Assert.assertEquals(columnNamesToCopy.size(), copiedSchema.columnCount());
+        Assert.assertEquals(df.rowCount(), copiedDataFrame.rowCount());
+        Assert.assertEquals(columnNamesToCopy.size(), copiedDataFrame.columnCount());
         for (int i = 0; i < columnNamesToCopy.size(); i++)
         {
-            DfColumn copyColumn = copiedSchema.getColumnAt(i);
+            DfColumn copyColumn = copiedDataFrame.getColumnAt(i);
             DfColumn sourceColumn = df.getColumnNamed(copyColumn.getName());
 
             Assert.assertEquals(sourceColumn.getName(), copyColumn.getName());
@@ -138,7 +120,7 @@ public class DataFrameCopyTest
             for (int j = 0; j < df.rowCount(); j++)
             {
                 Value cellValue = df.getColumnNamed(copyColumn.getName()).getValue(j);
-                Value copiedCellValue = copiedSchema.getColumnAt(i).getValue(j);
+                Value copiedCellValue = copiedDataFrame.getColumnAt(i).getValue(j);
 
                 Assert.assertEquals(0, cellValue.compareTo(copiedCellValue));
             }


### PR DESCRIPTION
Now it is possible to create a copy of a whole or parts of a DataFrame by calling `copy("new name")` and `copy("new name", List-of-columnNames )` methods that will return a new DataFrame with respectively all or selected columns from the original object.