### PR TITLE
Add copy() function to the DataFrame class as discussed in issue #11

### DIFF
--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrame.java
@@ -816,6 +816,40 @@ public class DataFrame
         return cloned;
     }
 
+    /**
+     * creates a copy of the whole data frame with the same schema as the original, including computed columns that
+     * are converted to stored columns of the same type
+     *
+     * @param newName the name for the new data frame
+     * @return a copy of the original data frame with the provided name and new schema
+     */
+    public DataFrame copy(String newName)
+    {
+        return this.copy(newName, null);
+    }
+
+    /**
+     * creates a copy of the parts of data frame with the same schema as the original, including computed columns that
+     * are converted to stored columns of the same type. Only the provided columns are copied to the new data frame.
+     * If the list is set to null, all columns are copied (behaving in the same way as copy(String newName)).
+     *
+     * @param newName the name for the new data frame
+     * @param columnNamesToCopy the names of the columns to be copied
+     * @return a copy of the original data frame with the provided name and new schema
+     */
+    public DataFrame copy(String newName, ListIterable<String> columnNamesToCopy)
+    {
+        DataFrame copied =  new DataFrame(newName);
+
+        ((columnNamesToCopy == null)
+                ? this.columns
+                : columnNamesToCopy.collect(this::getColumnNamed)
+        ).forEach(col -> col.copyTo(copied));
+
+        copied.seal();
+        return copied;
+    }
+
     public DataFrame sortBy(ListIterable<String> columnsToSortByNames)
     {
         return this.sortBy(columnsToSortByNames, null);

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumn.java
@@ -75,6 +75,8 @@ public interface DfColumn
 
     DfColumn mergeWithInto(DfColumn other, DataFrame target);
 
+    DfColumn copyTo(DataFrame target);
+
     default DfCellComparator columnComparator(DfColumn otherColumn)
     {
         throw exceptionByKey("DF_NO_COL_COMPARATOR")

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumnAbstract.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfColumnAbstract.java
@@ -99,6 +99,17 @@ implements DfColumn
         return newColumn;
     }
 
+    protected DfColumn copyColumnSchema(DataFrame target)
+    {
+        target.addColumn(this.getName(), this.getType());
+
+        DfColumnStored newColumn = (DfColumnStored) target.getColumnAt(target.columnCount() - 1);
+
+        newColumn.ensureInitialCapacity(this.getSize());
+
+        return newColumn;
+    }
+
     protected void throwAddingIncompatibleValueException(Value value)
     {
         exceptionByKey("DF_BAD_VAL_ADD_TO_COL")

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfDoubleColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfDoubleColumn.java
@@ -65,6 +65,14 @@ extends DfColumnAbstract
         return mergedCol;
     }
 
+    public DfColumn copyTo(DataFrame target)
+    {
+        DfDoubleColumn targetCol = (DfDoubleColumn) this.copyColumnSchema(target);
+
+        targetCol.addAllItemsFrom(this);
+        return targetCol;
+    }
+
     protected abstract void addAllItemsFrom(DfDoubleColumn doubleColumn);
 
     @Override

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfLongColumn.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfLongColumn.java
@@ -65,6 +65,14 @@ extends DfColumnAbstract
         return mergedCol;
     }
 
+    public DfColumn copyTo(DataFrame target)
+    {
+        DfLongColumn targetCol = (DfLongColumn)  this.copyColumnSchema(target);
+
+        targetCol.addAllItemsFrom(this);
+        return targetCol;
+    }
+
     protected abstract void addAllItemsFrom(DfLongColumn items);
 
     @Override

--- a/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfObjectColumnAbstract.java
+++ b/src/main/java/io/github/vmzakharov/ecdataframe/dataframe/DfObjectColumnAbstract.java
@@ -28,4 +28,12 @@ implements DfObjectColumn<T>
         mergedCol.addAllItems(((DfObjectColumnAbstract<T>) other).toList());
         return mergedCol;
     }
+
+    public DfColumn copyTo(DataFrame target)
+    {
+        DfObjectColumnAbstract<T> targetCol = (DfObjectColumnAbstract<T>) this.copyColumnSchema(target);
+
+        targetCol.addAllItems(this.toList());
+        return targetCol;
+    }
 }

--- a/src/test/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrameCopyTest.java
+++ b/src/test/java/io/github/vmzakharov/ecdataframe/dataframe/DataFrameCopyTest.java
@@ -1,5 +1,7 @@
 package io.github.vmzakharov.ecdataframe.dataframe;
 
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -9,7 +11,10 @@ public class DataFrameCopyTest
     public void copySchema()
     {
         DataFrame df = new DataFrame("df1");
-        df.addStringColumn("Name").addLongColumn("Count").addDoubleColumn("Value");
+        df
+                .addStringColumn("Name")
+                .addLongColumn("Count")
+                .addDoubleColumn("Value");
         df
                 .addRow("Alice", 5, 23.45)
                 .addRow("Bob",  10, 12.34)
@@ -43,7 +48,10 @@ public class DataFrameCopyTest
     public void copySchemaConvertComputedToStored()
     {
         DataFrame df = new DataFrame("df1");
-        df.addStringColumn("Name").addLongColumn("Count").addDoubleColumn("Value");
+        df
+                .addStringColumn("Name")
+                .addLongColumn("Count")
+                .addDoubleColumn("Value");
         df
                 .addRow("Alice", 5, 23.45)
                 .addRow("Bob",  10, 12.34)
@@ -66,5 +74,61 @@ public class DataFrameCopyTest
             Assert.assertTrue(copyColumn.isStored());
             Assert.assertSame(clonedSchema, copyColumn.getDataFrame());
         }
+    }
+
+    @Test
+    public void copyWholeDataFrame()
+    {
+        DataFrame df = new DataFrame("df1");
+        df
+                .addStringColumn("Name")
+                .addLongColumn("Count")
+                .addDoubleColumn("Value");
+        df
+                .addRow("Alice", 5, 23.45)
+                .addRow("Bob",  10, 12.34)
+                .addRow("Carl", 11, 56.78)
+                .addRow("Deb",   0,  7.89);
+
+        df.addDoubleColumn("Twice", "Value * 2");
+
+        DataFrame copiedDataFrame = df.copy("MyNewCopy");
+
+        DataFrameUtil.assertEquals(df, copiedDataFrame);
+
+    }
+
+    @Test
+    public void copySomeColumnsToANewDataFrame()
+    {
+        DataFrame originalDataFrame = new DataFrame("df1");
+        originalDataFrame
+                .addStringColumn("Name")
+                .addLongColumn("Count")
+                .addDoubleColumn("Value");
+
+        originalDataFrame
+                .addRow("Alice", 5, 23.45)
+                .addRow("Bob",  10, 12.34)
+                .addRow("Carl", 11, 56.78)
+                .addRow("Deb",   0,  7.89);
+
+        originalDataFrame.addDoubleColumn("Twice", "Value * 2");
+
+        DataFrame expectedDataFrame = new DataFrame("df2");
+        expectedDataFrame
+                .addStringColumn("Name")
+                .addDoubleColumn("Twice");
+
+        expectedDataFrame
+                .addRow("Alice",  46.9)
+                .addRow("Bob",    24.68)
+                .addRow("Carl",  113.56)
+                .addRow("Deb",    15.78);
+
+        ImmutableList<String> columnNamesToCopy = Lists.immutable.of("Name", "Twice");
+        DataFrame copiedDataFrame = originalDataFrame.copy("MyNewCopy", columnNamesToCopy);
+
+        DataFrameUtil.assertEquals(expectedDataFrame, copiedDataFrame);
     }
 }


### PR DESCRIPTION
It is now possible to create a copy of a whole or parts of a DataFrame by calling copy("new name") and copy("new name", list-of-columns) methods that will return a new DataFrame with respectively all or selected columns from the original object.